### PR TITLE
feat: Add header and dark theme

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { TRPCReactProvider } from "@/trpc/client";
 import { Toaster } from "sonner";
+import { ThemeProvider } from "next-themes";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -26,12 +27,19 @@ export default function RootLayout({
 }>) {
   return (
     <TRPCReactProvider>
-      <html lang="en">
+      <html lang="en" suppressHydrationWarning>
         <body
           className={`${geistSans.variable} ${geistMono.variable} antialiased`}
         >
-          <Toaster />
-          {children}
+          <ThemeProvider
+            attribute="class"
+            defaultTheme="system"
+            enableSystem
+            disableTransitionOnChange
+          >
+            <Toaster />
+            {children}
+          </ThemeProvider>
         </body>
       </html>
     </TRPCReactProvider>

--- a/src/inngest/functions.ts
+++ b/src/inngest/functions.ts
@@ -200,7 +200,7 @@ export const codeAgentFunction = inngest.createFunction(
 
     return {
       url: sandboxUrl,
-      title: "Frangment",
+      title: "Fragment",
       files: result.state.data.files,
       summary: result.state.data.summary,
     };

--- a/src/inngest/functions.ts
+++ b/src/inngest/functions.ts
@@ -200,7 +200,7 @@ export const codeAgentFunction = inngest.createFunction(
 
     return {
       url: sandboxUrl,
-      title: "Frangment ",
+      title: "Frangment",
       files: result.state.data.files,
       summary: result.state.data.summary,
     };

--- a/src/modules/projects/ui/components/message-card.tsx
+++ b/src/modules/projects/ui/components/message-card.tsx
@@ -98,7 +98,7 @@ const AssistantMessage = ({
 const UserMessage = ({ content }: UserMessageProps) => {
   return (
     <div className="flex justify-end pb-4 pr-2 pl-10">
-      <Card className="rounded-lg bg-muted p-3 shadow-none border-none max-w-[80%] breack-words">
+      <Card className="rounded-lg bg-muted p-3 shadow-none border-none max-w-[80%] break-words">
         {content}
       </Card>
     </div>

--- a/src/modules/projects/ui/components/message-loading.tsx
+++ b/src/modules/projects/ui/components/message-loading.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import Image from "next/image";
+import { useState, useEffect } from "react";
+
+const ShimmerMessages = () => {
+  const messages = [
+    "Thinking...",
+    "Loading...",
+    "Generating...",
+    "Analyzing your request...",
+    "Building your website...",
+    "Crafting components...",
+    "Optimizing layout...",
+    "Adding final touches...",
+    "Almost ready...",
+    "Querying large language model...",
+    "Retrieving relevant data...",
+    "Synthesizing response...",
+    "Refining output...",
+    "Applying machine learning magic...",
+    "Consulting neural networks...",
+    "Evaluating possibilities...",
+    "Aligning with best practices...",
+    "Double-checking results...",
+    "Ensuring accuracy...",
+    "Finalizing response...",
+  ];
+
+  const [currentMessageIndex, setCurrentMessageIndex] = useState(0);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setCurrentMessageIndex((prev) => (prev + 1) % messages.length);
+    }, 2000);
+
+    return () => clearInterval(interval);
+  }, [messages.length]);
+
+  return (
+    <div className="flex items-center gap-2">
+      <span className="text-base text-muted-foreground animate-pulse">
+        {messages[currentMessageIndex]}
+      </span>
+    </div>
+  );
+};
+
+export const MessageLoading = () => {
+  return (
+    <div className="flex flex-col group px-2 pb-4">
+      <div className="flex items-center gap-2 pl-2 mb-2">
+        <Image
+          src="/logo.svg"
+          alt="telos-logo"
+          width={18}
+          height={18}
+          className="shrink-0"
+        />
+        <span className="text-sm font-medium">Telos</span>
+      </div>
+
+      <div className="pl-8.5 flex flex-col gap-y-4">
+        <ShimmerMessages />
+      </div>
+    </div>
+  );
+};

--- a/src/modules/projects/ui/components/messages-container.tsx
+++ b/src/modules/projects/ui/components/messages-container.tsx
@@ -5,33 +5,48 @@ import { useSuspenseQuery } from "@tanstack/react-query";
 import MessageCard from "./message-card";
 import MessageForm from "./message-form";
 import { useEffect, useRef } from "react";
+import { Fragment } from "@/generated/prisma";
+import { MessageLoading } from "./message-loading";
 
 interface Props {
   projectId: string;
+  activeFragment: Fragment | null;
+  setActiveFragment: (fragment: Fragment | null) => void;
 }
 
-const MessagesContainer = ({ projectId }: Props) => {
+const MessagesContainer = ({
+  projectId,
+  activeFragment,
+  setActiveFragment,
+}: Props) => {
   const bottomRef = useRef<HTMLDivElement>(null);
   const trpc = useTRPC();
   const { data: messages } = useSuspenseQuery(
-    trpc.messages.getMany.queryOptions({
-      projectId: projectId,
-    })
+    trpc.messages.getMany.queryOptions(
+      {
+        projectId: projectId,
+      },
+      //TODO: temporary live message update
+      { refetchInterval: 5000 }
+    )
   );
 
-  useEffect(() => {
-    const lastAssistantMessage = messages.findLast(
-      (message) => message.role === "ASSISTANT"
-    );
+  // useEffect(() => {
+  //   const lastAssistantMessageWithFragment = messages.findLast(
+  //     (message) => message.role === "ASSISTANT" && !!message.fragment
+  //   );
 
-    if (lastAssistantMessage) {
-      //TODO: set active fragment
-    }
-  }, [messages]);
+  //   if (lastAssistantMessageWithFragment) {
+  //     setActiveFragment(lastAssistantMessageWithFragment.fragment);
+  //   }
+  // }, [messages, setActiveFragment]);
 
   useEffect(() => {
     bottomRef.current?.scrollIntoView();
   }, [messages.length]);
+
+  const lastMessage = messages[messages.length - 1];
+  const isLastMessageUser = lastMessage.role === "USER";
 
   return (
     <div className="flex flex-col flex-1 min-h-0">
@@ -44,12 +59,12 @@ const MessagesContainer = ({ projectId }: Props) => {
               role={message.role}
               fragment={message.fragment}
               createdAt={message.createdAt}
-              isActiveFragment={false}
+              isActiveFragment={activeFragment?.id === message.fragment?.id}
               type={message.type}
               onFragmentClick={() => {}}
             />
           ))}
-
+          {isLastMessageUser && <MessageLoading />}
           <div ref={bottomRef} />
         </div>
       </div>

--- a/src/modules/projects/ui/components/project-header.tsx
+++ b/src/modules/projects/ui/components/project-header.tsx
@@ -1,0 +1,91 @@
+import Link from "next/link";
+import Image from "next/image";
+import { useTheme } from "next-themes";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import {
+  ChevronDownIcon,
+  ChevronLeftIcon,
+  EditIcon,
+  SunMoonIcon,
+} from "lucide-react";
+import { useTRPC } from "@/trpc/client";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuPortal,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+
+interface Props {
+  projectId: string;
+}
+
+export const ProjectHeader = ({ projectId }: Props) => {
+  const trpc = useTRPC();
+  const { data: project } = useSuspenseQuery(
+    trpc.projects.getOne.queryOptions({ id: projectId })
+  );
+
+  const { theme, setTheme } = useTheme();
+
+  return (
+    <header className="p-2 flex justify-between items-center border-b">
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="focus-visible:ring-0 hover:bg-transparent hover:opacity-75 transition-opacity pl-2!"
+          >
+            <Image src="/logo.svg" alt="telos-logo" width={18} height={18} />
+            <span className="text-sm font-medium">{project.name}</span>
+            <ChevronDownIcon />
+          </Button>
+        </DropdownMenuTrigger>
+
+        <DropdownMenuContent side="bottom" align="start">
+          <DropdownMenuItem asChild>
+            <Link href="/">
+              <ChevronLeftIcon />
+              <span>Go Back</span>
+            </Link>
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
+
+          <DropdownMenuSub>
+            <DropdownMenuTrigger className="gap-2">
+              <SunMoonIcon className="size-4 text-muted-foreground" />
+              <span>Apperance</span>
+            </DropdownMenuTrigger>
+
+            <DropdownMenuPortal>
+              <DropdownMenuSubContent>
+                <DropdownMenuRadioGroup value={theme} onValueChange={setTheme}>
+                  <DropdownMenuRadioItem value="light">
+                    <span>Light</span>
+                  </DropdownMenuRadioItem>
+
+                  <DropdownMenuRadioItem value="dark">
+                    <span>Dark</span>
+                  </DropdownMenuRadioItem>
+
+                  <DropdownMenuRadioItem value="system">
+                    <span>System</span>
+                  </DropdownMenuRadioItem>
+                </DropdownMenuRadioGroup>
+              </DropdownMenuSubContent>
+            </DropdownMenuPortal>
+          </DropdownMenuSub>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </header>
+  );
+};

--- a/src/modules/projects/ui/views/project-view.tsx
+++ b/src/modules/projects/ui/views/project-view.tsx
@@ -5,13 +5,16 @@ import {
   ResizablePanelGroup,
 } from "@/components/ui/resizable";
 import MessagesContainer from "../components/messages-container";
-import { Suspense } from "react";
+import { Suspense, useState } from "react";
+import { Fragment } from "@/generated/prisma";
+import { ProjectHeader } from "../components/project-header";
 
 interface Props {
   projectId: string;
 }
 
 const ProjectView = ({ projectId }: Props) => {
+  const [activeFragment, setActiveFragment] = useState<Fragment | null>(null);
   return (
     <div className="h-screen">
       <ResizablePanelGroup direction="horizontal">
@@ -20,8 +23,15 @@ const ProjectView = ({ projectId }: Props) => {
           minSize={20}
           className="flex flex-col min-h-0"
         >
+          <Suspense fallback={<p>Loading project...</p>}>
+            <ProjectHeader projectId={projectId} />
+          </Suspense>
           <Suspense fallback={<p>Loading...</p>}>
-            <MessagesContainer projectId={projectId} />
+            <MessagesContainer
+              projectId={projectId}
+              activeFragment={activeFragment}
+              setActiveFragment={setActiveFragment}
+            />
           </Suspense>
         </ResizablePanel>
 


### PR DESCRIPTION
Use shadcn to add dropdown menu and theme provider to chage from light to dark mode

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a project header with theme selection and navigation options.
  * Added a loading indicator with dynamic messages for message lists.
  * Enabled theme management based on system preferences.

* **Enhancements**
  * Improved message container with live updates and active fragment state management.
  * Project view now displays a header and manages active message fragments.

* **Bug Fixes**
  * Corrected typos in UI class names and message titles for improved display and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->